### PR TITLE
refactor: replace console statements with centralized logging infrastructure

### DIFF
--- a/apps/api/src/claudeUsage.ts
+++ b/apps/api/src/claudeUsage.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { type ClaudeUsageSnapshot, asNumber, asRecord, asString } from "@octogent/core";
-import { logVerbose } from "./logging";
+import { logVerbose, logWarn } from "./logging";
 import { toResetIso } from "./usageUtils";
 
 const CLAUDE_CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
@@ -459,7 +459,7 @@ const persistOkSnapshot = async (
     await mkdir(dirname(snapshotPath), { recursive: true });
     await writeFile(snapshotPath, JSON.stringify(snapshot), "utf8");
   } catch (error) {
-    console.warn(
+    logWarn(
       `[claude-usage] unable to persist snapshot: ${error instanceof Error ? error.message : String(error)}`,
     );
   }

--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { basename, join, resolve } from "node:path";
 
+import { logError, logInfo, logWarn } from "./logging";
 import {
   ensureOctogentGitignoreEntry,
   ensureProjectScaffold,
@@ -100,13 +101,13 @@ const initProject = (name?: string) => {
   const projectPath = process.cwd();
   const { created, projectConfig, projectStateDir } = initializeProject(projectPath, name);
 
-  console.log(
+  logInfo(
     `${created ? "Initialized" : "Updated"} Octogent project "${projectConfig.displayName}" at ${projectPath}`,
   );
-  console.log("  .octogent/ directory ready (project metadata, tentacles, worktrees)");
-  console.log(`  Global state: ${projectStateDir}`);
-  console.log("  .gitignore updated");
-  console.log("\nRun `octogent` to start the dashboard.");
+  logInfo("  .octogent/ directory ready (project metadata, tentacles, worktrees)");
+  logInfo(`  Global state: ${projectStateDir}`);
+  logInfo("  .gitignore updated");
+  logInfo("\nRun `octogent` to start the dashboard.");
 };
 
 const canListenOnPort = (port: number): Promise<boolean> =>
@@ -169,7 +170,7 @@ const resolveRuntimeApiBase = () => {
 };
 
 const apiError = () => {
-  console.error(
+  logError(
     `Error: Could not reach API at ${resolveRuntimeApiBase()}. Start Octogent in this project first.`,
   );
   process.exit(1);
@@ -204,15 +205,15 @@ const startServer = async () => {
   if (startupPrerequisiteLines.length > 0) {
     for (const line of startupPrerequisiteLines) {
       if (startupPrerequisiteReport.errors.length > 0) {
-        console.error(line);
+        logError(line);
       } else {
-        console.warn(line);
+        logWarn(line);
       }
     }
     if (startupPrerequisiteReport.errors.length > 0) {
       process.exit(1);
     }
-    console.warn("");
+    logWarn("");
   }
 
   const workspaceCwd = process.cwd();
@@ -256,20 +257,20 @@ const startServer = async () => {
     maybeOpenBrowser(apiBaseUrl);
   }
 
-  console.log();
-  console.log("  Octogent is running");
-  console.log(`  Project: ${workspaceCwd}`);
-  console.log(`  Name:    ${projectDisplayName}`);
-  console.log(`  API:     ${apiBaseUrl}`);
+  logInfo();
+  logInfo("  Octogent is running");
+  logInfo(`  Project: ${workspaceCwd}`);
+  logInfo(`  Name:    ${projectDisplayName}`);
+  logInfo(`  API:     ${apiBaseUrl}`);
   if (hasWebDist) {
-    console.log(`  UI:      ${apiBaseUrl}`);
+    logInfo(`  UI:      ${apiBaseUrl}`);
   } else {
-    console.log("  UI:      bundled web assets are missing from this install");
+    logInfo("  UI:      bundled web assets are missing from this install");
   }
   if (!isInitialized) {
-    console.log("  Setup:   workspace is not initialized yet; use the in-app setup flow");
+    logInfo("  Setup:   workspace is not initialized yet; use the in-app setup flow");
   }
-  console.log();
+  logInfo();
 };
 
 const COLORS = [
@@ -327,14 +328,14 @@ const parseJsonFlag = (flag: string): Record<string, string> | undefined => {
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      console.error(`Error: ${flag} must be a JSON object.`);
+      logError(`Error: ${flag} must be a JSON object.`);
       process.exit(1);
     }
 
     const entries = Object.entries(parsed).filter(([, value]) => typeof value === "string");
     return Object.fromEntries(entries);
   } catch {
-    console.error(`Error: ${flag} must be valid JSON.`);
+    logError(`Error: ${flag} must be valid JSON.`);
     process.exit(1);
   }
 };
@@ -342,7 +343,7 @@ const parseJsonFlag = (flag: string): Record<string, string> | undefined => {
 const tentacleCreate = async () => {
   const name = args[2];
   if (!name || name.startsWith("-")) {
-    console.error("Error: tentacle name is required.");
+    logError("Error: tentacle name is required.");
     process.exit(1);
   }
 
@@ -358,10 +359,10 @@ const tentacleCreate = async () => {
     });
     const data = (await response.json()) as Record<string, unknown>;
     if (!response.ok) {
-      console.error(`Error: ${data.error ?? "Failed"}`);
+      logError(`Error: ${data.error ?? "Failed"}`);
       process.exit(1);
     }
-    console.log(`Created tentacle "${data.tentacleId}"`);
+    logInfo(`Created tentacle "${data.tentacleId}"`);
   } catch {
     apiError();
   }
@@ -373,19 +374,19 @@ const tentacleList = async () => {
   try {
     const response = await fetch(`${apiBase}/api/deck/tentacles`);
     if (!response.ok) {
-      console.error("Error: failed to fetch tentacles.");
+      logError("Error: failed to fetch tentacles.");
       process.exit(1);
     }
 
     const tentacles = (await response.json()) as Array<Record<string, unknown>>;
     if (tentacles.length === 0) {
-      console.log("No tentacles found.");
+      logInfo("No tentacles found.");
       return;
     }
 
     for (const tentacle of tentacles) {
       const description = tentacle.description ? ` — ${tentacle.description}` : "";
-      console.log(`  ${tentacle.tentacleId}${description}`);
+      logInfo(`  ${tentacle.tentacleId}${description}`);
     }
   } catch {
     apiError();
@@ -427,10 +428,10 @@ const terminalCreate = async () => {
     });
     const data = (await response.json()) as Record<string, unknown>;
     if (!response.ok) {
-      console.error(`Error: ${data.error ?? "Failed"}`);
+      logError(`Error: ${data.error ?? "Failed"}`);
       process.exit(1);
     }
-    console.log(`Created terminal "${data.terminalId}"`);
+    logInfo(`Created terminal "${data.terminalId}"`);
   } catch {
     apiError();
   }
@@ -439,7 +440,7 @@ const terminalCreate = async () => {
 const channelSend = async () => {
   const terminalId = args[2];
   if (!terminalId || terminalId.startsWith("-")) {
-    console.error("Error: target terminalId is required.");
+    logError("Error: target terminalId is required.");
     process.exit(1);
   }
 
@@ -462,7 +463,7 @@ const channelSend = async () => {
           .trim();
 
   if (!message) {
-    console.error("Error: message content is required.");
+    logError("Error: message content is required.");
     process.exit(1);
   }
 
@@ -478,10 +479,10 @@ const channelSend = async () => {
     );
     const data = (await response.json()) as Record<string, unknown>;
     if (!response.ok) {
-      console.error(`Error: ${data.error ?? "Failed"}`);
+      logError(`Error: ${data.error ?? "Failed"}`);
       process.exit(1);
     }
-    console.log(`Message sent (${data.messageId}) to ${terminalId}`);
+    logInfo(`Message sent (${data.messageId}) to ${terminalId}`);
   } catch {
     apiError();
   }
@@ -490,7 +491,7 @@ const channelSend = async () => {
 const channelList = async () => {
   const terminalId = args[2];
   if (!terminalId || terminalId.startsWith("-")) {
-    console.error("Error: terminalId is required.");
+    logError("Error: terminalId is required.");
     process.exit(1);
   }
 
@@ -501,19 +502,19 @@ const channelList = async () => {
     );
     const data = (await response.json()) as Record<string, unknown>;
     if (!response.ok) {
-      console.error(`Error: ${data.error ?? "Failed"}`);
+      logError(`Error: ${data.error ?? "Failed"}`);
       process.exit(1);
     }
 
     const messages = (data.messages ?? []) as Array<Record<string, unknown>>;
     if (messages.length === 0) {
-      console.log(`No messages for ${terminalId}.`);
+      logInfo(`No messages for ${terminalId}.`);
       return;
     }
 
     for (const message of messages) {
       const status = message.delivered ? "delivered" : "pending";
-      console.log(
+      logInfo(
         `  [${message.messageId}] from=${message.fromTerminalId || "(unknown)"} status=${status}: ${message.content}`,
       );
     }
@@ -534,14 +535,14 @@ const main = async () => {
   if (command === "projects" || command === "project") {
     const projects = loadProjectsRegistry().projects;
     if (projects.length === 0) {
-      console.log(
+      logInfo(
         "No projects registered yet. Run `octogent` or `octogent init` in a project directory.",
       );
       return;
     }
 
     for (const project of projects) {
-      console.log(`  ${project.name}  ${project.id}  ${project.path}`);
+      logInfo(`  ${project.name}  ${project.id}  ${project.path}`);
     }
     return;
   }
@@ -570,7 +571,7 @@ const main = async () => {
     }
   }
 
-  console.log(`Usage:
+  logInfo(`Usage:
   octogent                             Start the dashboard in the current project
   octogent init [project-name]         Initialize the current directory explicitly
   octogent projects                    List registered projects

--- a/apps/api/src/createApiServer/requestHandler.ts
+++ b/apps/api/src/createApiServer/requestHandler.ts
@@ -8,7 +8,7 @@ import type { ClaudeUsageSnapshot } from "../claudeUsage";
 import type { CodeIntelStore } from "../codeIntelStore";
 import type { CodexUsageSnapshot } from "../codexUsage";
 import type { GitHubRepoSummarySnapshot } from "../githubRepoSummary";
-import { logVerbose } from "../logging";
+import { logError, logVerbose } from "../logging";
 import type { MonitorService } from "../monitor";
 import { handleCodeIntelEventsRoute } from "./codeIntelRoutes";
 import {
@@ -177,7 +177,7 @@ const serveStaticFile = async (
   } catch (error) {
     const code = typeof error === "object" && error && "code" in error ? String(error.code) : "";
     if (code !== "ENOENT") {
-      console.error(
+      logError(
         `[API] Static file error: ${filePath}`,
         error instanceof Error ? error.message : error,
       );
@@ -293,7 +293,7 @@ export const createApiRequestHandler = ({
       writeJson(response, 404, { error: "Not found" }, corsOrigin);
       logRequest(request.method ?? "?", requestUrl.pathname, statusCode, startTime);
     } catch (error) {
-      console.error(
+      logError(
         `[API] Unhandled error: ${request.method ?? "?"} ${request.url ?? "/"}`,
         error instanceof Error ? (error.stack ?? error.message) : error,
       );

--- a/apps/api/src/logging.ts
+++ b/apps/api/src/logging.ts
@@ -7,3 +7,15 @@ export const logVerbose = (...args: Parameters<typeof console.log>): void => {
     console.log(...args);
   }
 };
+
+export const logInfo = (...args: Parameters<typeof console.log>): void => {
+  console.log(...args);
+};
+
+export const logWarn = (...args: Parameters<typeof console.warn>): void => {
+  console.warn(...args);
+};
+
+export const logError = (...args: Parameters<typeof console.error>): void => {
+  console.error(...args);
+};

--- a/apps/api/src/projectPersistence.ts
+++ b/apps/api/src/projectPersistence.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
+import { logInfo } from "./logging";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -372,6 +373,6 @@ export const migrateStateToGlobal = (workspaceCwd: string, projectStateDir: stri
   }
 
   if (migrated > 0) {
-    console.log(`  Migrated state to ${projectStateDir}`);
+    logInfo(`  Migrated state to ${projectStateDir}`);
   }
 };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { createApiServer } from "./createApiServer";
+import { logError, logInfo, logWarn } from "./logging";
 
 const parsePort = (value: string | undefined, fallback: number) => {
   if (!value) {
@@ -27,20 +28,20 @@ const validateStartupEnv = () => {
   if (rawPort !== undefined) {
     const parsed = Number.parseInt(rawPort, 10);
     if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
-      console.error(`Invalid port "${rawPort}": must be an integer between 1 and 65535.`);
+      logError(`Invalid port "${rawPort}": must be an integer between 1 and 65535.`);
       process.exit(1);
     }
   }
 
   if (process.env.OCTOGENT_WORKSPACE_CWD && !existsSync(process.env.OCTOGENT_WORKSPACE_CWD)) {
-    console.error(
+    logError(
       `OCTOGENT_WORKSPACE_CWD directory does not exist: ${process.env.OCTOGENT_WORKSPACE_CWD}`,
     );
     process.exit(1);
   }
 
   if (process.env.OCTOGENT_WEB_DIST_DIR && !existsSync(process.env.OCTOGENT_WEB_DIST_DIR)) {
-    console.warn(
+    logWarn(
       `OCTOGENT_WEB_DIST_DIR directory does not exist: ${process.env.OCTOGENT_WEB_DIST_DIR} — web UI will be unavailable.`,
     );
   }
@@ -72,9 +73,9 @@ process.on("SIGTERM", () => {
 apiServer
   .start(port, host)
   .then(({ port: activePort }) => {
-    console.log(`Octogent API listening on http://${host}:${activePort}`);
+    logInfo(`Octogent API listening on http://${host}:${activePort}`);
   })
   .catch((error: unknown) => {
-    console.error(error);
+    logError(error);
     process.exit(1);
   });

--- a/apps/api/src/terminalRuntime/registry.ts
+++ b/apps/api/src/terminalRuntime/registry.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { logWarn } from "../logging";
 import { TERMINAL_REGISTRY_VERSION } from "./constants";
 
 import { toErrorMessage } from "./systemClients";
@@ -369,7 +370,7 @@ export const createTerminalRegistryPersistence = (registryPath: string) => {
           await writeSerializedRegistry(registryPath, serialized);
           lastPersistedSerialized = serialized;
         } catch (error) {
-          console.warn("[terminal-registry] Failed to persist registry:", error);
+          logWarn("[terminal-registry] Failed to persist registry:", error);
         }
       }
     })().finally(() => {


### PR DESCRIPTION
Replaced scattered console.log/warn/error calls throughout the API codebase with a centralized logging infrastructure (logInfo, logWarn, logError) from apps/api/src/logging.ts.

Changes:
- Enhanced logging.ts with logInfo, logWarn, and logError functions
- Updated apps/api/src/cli.ts (39 console → logging calls)
- Updated apps/api/src/server.ts (5 console → logging calls)
- Updated apps/api/src/claudeUsage.ts (1 console.warn → logWarn)
- Updated apps/api/src/projectPersistence.ts (1 console.log → logInfo)
- Updated apps/api/src/terminalRuntime/registry.ts (1 console.warn → logWarn)
- Updated apps/api/src/createApiServer/requestHandler.ts (2 console.error → logError)

Impact:
- Improved log consistency across the API
- Better separation of concerns
- Foundation for future log filtering/formatting
- No functional changes to behavior
- No API or workflow changes
- No persistence impact

Testing:
- All 228 tests pass (packages/core: 3, apps/api: 144, apps/web: 81)
- Build succeeds
- Lint passes (only pre-existing formatting issues in config files)