### PR TITLE
feat: error boundary, UI state flush fix, design system polish, swarm…

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,6 +27,7 @@ import type { TerminalView } from "./app/types";
 import { clampSidebarWidth } from "./app/uiStateNormalizers";
 import { ActiveAgentsSidebar } from "./components/ActiveAgentsSidebar";
 import { ConsolePrimaryNav } from "./components/ConsolePrimaryNav";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { PrimaryViewRouter } from "./components/PrimaryViewRouter";
 import { RuntimeStatusStrip } from "./components/RuntimeStatusStrip";
 import { SidebarActionPanel } from "./components/SidebarActionPanel";
@@ -462,6 +463,7 @@ export const App = () => {
               />
             )}
 
+          <ErrorBoundary label="PrimaryView">
           <PrimaryViewRouter
             activePrimaryNav={activePrimaryNav}
             deckPrimaryViewProps={{
@@ -635,6 +637,7 @@ export const App = () => {
             promptsEnabled={isUiStateHydrated && activePrimaryNav === 7}
             onPromptsSidebarContent={setPromptsSidebarContent}
           />
+          </ErrorBoundary>
         </div>
       </section>
 

--- a/apps/web/src/app/hooks/usePersistedUiState.ts
+++ b/apps/web/src/app/hooks/usePersistedUiState.ts
@@ -419,6 +419,29 @@ export const usePersistedUiState = ({
     setCanvasOpenTentacleIds((current) => retainActiveTerminalIds(current, activeTentacleIds));
   }, [columns]);
 
+  // Flush pending UI state synchronously on tab close so the debounce window
+  // cannot cause state loss when the user navigates away mid-debounce.
+  const pendingUiStateRef = useRef<FrontendUiStateSnapshot | null>(null);
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const pending = pendingUiStateRef.current;
+      if (!pending) {
+        return;
+      }
+      // sendBeacon survives the page unload and does not block the browser.
+      const body = JSON.stringify(pending);
+      const url = buildUiStateUrl();
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(url, new Blob([body], { type: "application/json" }));
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
   useEffect(() => {
     if (!isUiStateHydrated) {
       return;
@@ -445,8 +468,11 @@ export const usePersistedUiState = ({
     });
 
     if (areUiStateSnapshotsEqual(lastPersistedUiStateRef.current, payload)) {
+      pendingUiStateRef.current = null;
       return;
     }
+
+    pendingUiStateRef.current = payload;
 
     const timerId = window.setTimeout(() => {
       void fetch(buildUiStateUrl(), {
@@ -462,6 +488,7 @@ export const usePersistedUiState = ({
             throw new Error(`Unexpected status ${response.status}`);
           }
           lastPersistedUiStateRef.current = payload;
+          pendingUiStateRef.current = null;
         })
         .catch((error: unknown) => {
           console.warn("[ui-state] Failed to persist UI state:", error);

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  /** Optional label shown in the error panel for easier identification. */
+  label?: string;
+  /** Called when an error is caught — useful for logging / telemetry. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+};
+
+type State = {
+  error: Error | null;
+};
+
+/**
+ * Catches render errors inside any primary view so a single broken panel
+ * cannot white-screen the entire shell.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+    console.error(`[ErrorBoundary:${this.props.label ?? "unknown"}] Caught render error:`, error, info);
+  }
+
+  private handleReset = () => {
+    this.setState({ error: null });
+  };
+
+  override render() {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="error-boundary-panel">
+        <div className="error-boundary-content">
+          <span className="error-boundary-icon">⚠</span>
+          <p className="error-boundary-title">
+            {this.props.label ? `${this.props.label} crashed` : "Something went wrong"}
+          </p>
+          <p className="error-boundary-message">{error.message}</p>
+          <button type="button" className="error-boundary-reset" onClick={this.handleReset}>
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/web/src/styles/chrome-and-buttons.css
+++ b/apps/web/src/styles/chrome-and-buttons.css
@@ -1,6 +1,8 @@
 .chrome {
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-surface-2);
+  /* Subtle inner highlight at the top edge */
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 3%, transparent);
   padding: 0.3rem 0.45rem;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -231,9 +233,11 @@
   margin-top: 2px;
   z-index: 100;
   min-width: 9rem;
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-medium);
   background: var(--bg-surface-2);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.5),
+    0 1px 0 color-mix(in srgb, #fff 4%, transparent) inset;
   display: flex;
   flex-direction: column;
   padding: 0.15rem 0;

--- a/apps/web/src/styles/console-theme-tokens.css
+++ b/apps/web/src/styles/console-theme-tokens.css
@@ -1,25 +1,94 @@
 :root {
-  --bg-canvas: #050607;
-  --bg-surface-1: #0b0d10;
-  --bg-surface-2: #12151b;
-  --border-subtle: #2b2f36;
-  --text-primary: #e6e8ec;
-  --text-secondary: #a9b0ba;
-  --accent-primary: #d6a21a;
-  --term-red: #8c0b12;
-  --term-green: #25d366;
-  --term-blue: #0d2a57;
+  /* ── Surfaces ─────────────────────────────────────────────────────────── */
+  --bg-canvas: #03050a;
+  --bg-surface-1: #080c12;
+  --bg-surface-2: #0e1520;
+  --bg-surface-3: #141d2b;
+
+  /* ── Borders ──────────────────────────────────────────────────────────── */
+  --border-subtle: #1e2736;
+  --border-medium: #273040;
+  --border-strong: #344055;
+
+  /* ── Text ─────────────────────────────────────────────────────────────── */
+  --text-primary: #e8ecf2;
+  --text-secondary: #8a95a5;
+  --text-muted: #4f5a6a;
+
+  /* ── Accent — refined amber ───────────────────────────────────────────── */
+  --accent-primary: #e8a820;
+  --accent-glow: color-mix(in srgb, #e8a820 28%, transparent);
+  --accent-glow-strong: color-mix(in srgb, #e8a820 48%, transparent);
+
+  /* ── Status colors ────────────────────────────────────────────────────── */
+  --term-red: #c0162a;
+  --term-red-glow: color-mix(in srgb, #c0162a 30%, transparent);
+  --term-green: #20c05a;
+  --term-green-glow: color-mix(in srgb, #20c05a 28%, transparent);
+  --term-blue: #1a4a8a;
   --term-warning: #ffb020;
-  --terminal-bg: #101722;
-  --terminal-header-bg-top: #254570;
-  --terminal-header-bg-bottom: #1e385a;
-  --terminal-header-text: #e6e8ec;
-  --control-border-strong: #2b2f36;
-  --control-bg-strong: #0b0d10;
+
+  /* ── Terminal panel ───────────────────────────────────────────────────── */
+  --terminal-bg: #0b1118;
+  --terminal-header-bg-top: #1a3260;
+  --terminal-header-bg-bottom: #142852;
+  --terminal-header-text: #cdd5e0;
+
+  /* ── Controls ─────────────────────────────────────────────────────────── */
+  --control-border-strong: #1e2736;
+  --control-bg-strong: #080c12;
+
+  /* ── Sidebar — subtle blue-tinted darks ───────────────────────────────── */
+  --sidebar-canvas: color-mix(in srgb, var(--bg-surface-1) 82%, #0a1020 18%);
+  --sidebar-panel: color-mix(in srgb, var(--bg-surface-1) 76%, #0c1528 24%);
+  --sidebar-card: color-mix(in srgb, var(--bg-surface-1) 80%, #0d1726 20%);
+  --sidebar-header: color-mix(in srgb, var(--bg-surface-2) 70%, #121e32 30%);
+  --sidebar-row: color-mix(in srgb, var(--bg-surface-1) 86%, #0e1a28 14%);
+  --sidebar-row-hover: color-mix(in srgb, var(--sidebar-row) 74%, #1a2d44 26%);
+  --sidebar-row-active: color-mix(in srgb, var(--sidebar-row) 60%, #1e3450 40%);
+  --sidebar-border: color-mix(in srgb, var(--border-subtle) 70%, #1e2d40 30%);
+  --sidebar-border-strong: color-mix(in srgb, var(--border-subtle) 46%, #283c55 54%);
+  --sidebar-text-muted: color-mix(in srgb, var(--text-secondary) 82%, #8aa0bc 18%);
+
+  /* ── Scrollbars ───────────────────────────────────────────────────────── */
+  --scrollbar-size: 6px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: color-mix(in srgb, var(--border-strong) 60%, transparent);
+  --scrollbar-thumb-hover: color-mix(in srgb, var(--accent-primary) 40%, var(--border-strong) 60%);
+  --scrollbar-thumb-active: color-mix(in srgb, var(--accent-primary) 65%, var(--border-strong) 35%);
+  --terminal-scrollbar-track: transparent;
+  --terminal-scrollbar-thumb: color-mix(in srgb, var(--accent-primary) 25%, var(--terminal-bg) 75%);
+  --terminal-scrollbar-thumb-hover: color-mix(in srgb, var(--accent-primary) 40%, var(--terminal-bg) 60%);
+  --terminal-scrollbar-thumb-active: color-mix(in srgb, var(--accent-primary) 55%, var(--terminal-bg) 45%);
+
   --ui-base-font-size: 17px;
 }
 
 body {
-  background: radial-gradient(circle at top right, #11161e 0%, var(--bg-canvas) 54%);
+  /* Multi-layer gradient: deep blue-black canvas with subtle top-right warm glow */
+  background:
+    radial-gradient(ellipse 60% 50% at 100% 0%, #0e1a2a 0%, transparent 70%),
+    radial-gradient(ellipse 40% 30% at 0% 100%, #0a0f18 0%, transparent 60%),
+    linear-gradient(160deg, #050b14 0%, var(--bg-canvas) 50%);
+  color: var(--text-primary);
+}
+
+/* ── Global transition polish ─────────────────────────────────────────────── */
+
+button,
+[role="button"] {
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease,
+    box-shadow 120ms ease, opacity 120ms ease;
+}
+
+/* ── Focus ring ───────────────────────────────────────────────────────────── */
+:focus-visible {
+  outline: 1.5px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+/* ── Selection ────────────────────────────────────────────────────────────── */
+::selection {
+  background: color-mix(in srgb, var(--accent-primary) 30%, transparent);
   color: var(--text-primary);
 }

--- a/apps/web/src/styles/foundation.css
+++ b/apps/web/src/styles/foundation.css
@@ -75,6 +75,9 @@ body {
   background: radial-gradient(circle at top right, #111111, var(--bg-canvas) 50%);
   color: var(--text-primary);
   overflow: hidden;
+  /* Smooth subpixel rendering */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .page {
@@ -97,4 +100,73 @@ body {
 
 .workspace-shell--full {
   grid-template-columns: 1fr;
+}
+
+/* ── Error Boundary ─────────────────────────────────────────────────────── */
+
+.error-boundary-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 2rem;
+  background: var(--bg-canvas);
+}
+
+.error-boundary-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 480px;
+  text-align: center;
+  padding: 2rem;
+  border: 1px solid color-mix(in srgb, var(--term-red) 40%, transparent);
+  background: color-mix(in srgb, var(--term-red) 6%, var(--bg-surface-1));
+  border-radius: 4px;
+}
+
+.error-boundary-icon {
+  font-size: 1.5rem;
+  color: var(--term-red);
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--term-red) 50%, transparent));
+}
+
+.error-boundary-title {
+  margin: 0;
+  font-family: var(--font-main);
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-primary);
+}
+
+.error-boundary-message {
+  margin: 0;
+  font-family: var(--font-main);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.error-boundary-reset {
+  margin-top: 0.5rem;
+  padding: 0.35rem 1rem;
+  background: transparent;
+  border: 1px solid var(--accent-primary);
+  color: var(--accent-primary);
+  font-family: var(--font-main);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.error-boundary-reset:hover {
+  background: color-mix(in srgb, var(--accent-primary) 15%, transparent);
+  color: var(--text-primary);
 }

--- a/apps/web/src/styles/terminal-and-status.css
+++ b/apps/web/src/styles/terminal-and-status.css
@@ -30,11 +30,13 @@
 .terminal-pane--selected .terminal-header {
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--accent-primary) 90%, #ffd89d 10%) 0%,
-    color-mix(in srgb, var(--accent-primary) 78%, #d9851c 22%) 100%
+    color-mix(in srgb, var(--accent-primary) 88%, #ffe0a0 12%) 0%,
+    color-mix(in srgb, var(--accent-primary) 72%, #c07010 28%) 100%
   );
-  border-bottom-color: color-mix(in srgb, #121212 35%, transparent);
-  color: #121212;
+  border-bottom-color: color-mix(in srgb, #080808 40%, transparent);
+  /* Subtle top glow on the selected terminal to make it feel "active" */
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 14%, transparent);
+  color: #0a0a0a;
 }
 
 .terminal-header[data-connection-state="connected"] {
@@ -290,12 +292,14 @@
 .status-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.1rem 0.35rem;
+  padding: 0.1rem 0.38rem;
   border: 1px solid var(--border-subtle);
   color: #000000;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
+  letter-spacing: 0.04em;
   white-space: nowrap;
+  border-radius: 2px;
 }
 
 .status-badge__compact {
@@ -305,35 +309,45 @@
 .pill.live,
 .status-badge.live {
   background: var(--term-green);
+  border-color: color-mix(in srgb, var(--term-green) 60%, #000);
+  box-shadow: 0 0 6px var(--term-green-glow);
 }
 
 .pill.idle,
 .status-badge.idle {
   background: var(--term-blue);
-  color: #f5fbff;
+  border-color: color-mix(in srgb, var(--term-blue) 80%, #000);
+  color: #dbeeff;
 }
 
 .pill.processing,
 .status-badge.processing {
   background: var(--term-green);
-  color: #031700;
+  border-color: color-mix(in srgb, var(--term-green) 60%, #000);
+  box-shadow: 0 0 8px var(--term-green-glow);
+  color: #021200;
 }
 
 .pill.queued,
 .status-badge.queued {
   background: var(--term-warning);
+  border-color: color-mix(in srgb, var(--term-warning) 60%, #000);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--term-warning) 25%, transparent);
 }
 
 .pill.blocked,
 .status-badge.blocked {
   background: var(--term-red);
-  color: #fff3f3;
+  border-color: color-mix(in srgb, var(--term-red) 60%, #000);
+  box-shadow: 0 0 8px var(--term-red-glow);
+  color: #fff0f0;
 }
 
 .pill.warning,
 .status-badge.warning {
   background: var(--term-warning);
-  color: #1a1000;
+  border-color: color-mix(in srgb, var(--term-warning) 60%, #000);
+  color: #140900;
 }
 
 @media (max-width: 700px) {

--- a/prompts/swarm-parent.md
+++ b/prompts/swarm-parent.md
@@ -62,6 +62,23 @@ Not all worker signals mean the same thing. Match your response to their state:
 - **BLOCKED** — Worker is stuck. Read their message carefully, investigate the issue (check their branch, read relevant code), and send specific, actionable guidance. Don't send vague encouragement like "try again" or "keep going."
 - **Silent** — A worker that hasn't reported in a while may be stuck without knowing how to ask for help, or may still be working. Check their channel. If no messages after two check cycles, send a status request.
 
+### Timeout and Escalation Protocol
+
+Use this protocol to avoid waiting indefinitely on a stalled worker:
+
+1. **First check (after 2 cycles of silence):** Send a status ping.
+   ```bash
+   node bin/octogent channel send <workerTerminalId> "STATUS?" --from {{terminalId}}
+   ```
+2. **No reply after another cycle:** Read the worker's last output to determine if it is actively running or stuck.
+3. **Worker is visibly stuck or loops on the same action:** Send targeted guidance with the exact next step. Be specific — name the file, line, or command.
+4. **Worker remains unresponsive after direct guidance:** Escalate by sending:
+   ```
+   ABORT: Stop all current work. Report your completed state and any uncommitted changes.
+   ```
+   Then, if there is a clean partial result on the branch, review and merge what can be used. Log the failed item in the tentacle `todo.md` for the next swarm.
+5. **Never block the entire swarm on one silent worker.** Once all other workers are DONE and the stuck worker has been given at least two direct guidance messages without response, proceed with merging the completed work and mark the failed item as deferred.
+
 ## Worker Workspaces
 
 {{workerWorkspaceSection}}
@@ -77,6 +94,8 @@ Watch for these in your own behavior:
 1. **Premature completion** — Declaring the swarm done when workers have gone quiet but haven't explicitly reported DONE. Silence is not confirmation.
 2. **Blind merging** — Merging branches without reading the diff. A worker may have committed partial work, unrelated changes, or broken tests.
 3. **Ignoring BLOCKED** — A blocked worker won't unblock itself. Every BLOCKED message needs investigation and a response from you.
+4. **Infinite waiting** — Waiting indefinitely on a silent worker instead of escalating. Apply the Timeout and Escalation Protocol above.
+5. **Taking over a worker's task** — If a worker is BLOCKED, guide it. If it fails completely, defer the task — never start doing the worker's task yourself, which would duplicate effort and risk merge conflicts.
 
 Your terminal ID is `{{terminalId}}`. The API is at `http://localhost:{{apiPort}}`.
 

--- a/scripts/dev-preview.sh
+++ b/scripts/dev-preview.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PATH="/Users/carsonwilson/.nvm/versions/node/v24.14.1/bin:$PATH"
+cd /Users/carsonwilson/octogent
+exec node scripts/dev.mjs


### PR DESCRIPTION
… prompt escalation

## Web

- Add `ErrorBoundary` class component wrapping `PrimaryViewRouter` so a single crashing view can never white-screen the entire shell. Includes styled recovery panel with error message and "Try again" reset button.

- Fix UI state loss on tab close: add a `beforeunload` listener in `usePersistedUiState` that fires `navigator.sendBeacon` with any pending state that hasn't been flushed through the 250 ms debounce yet.

## Design system

- Upgrade `console-theme-tokens.css` with a refined deep navy-black palette, multi-layer body gradient, new `--accent-glow`, `--term-red-glow`, and `--term-green-glow` tokens, thinner 6 px scrollbars, `::selection` and `:focus-visible` polish, and global button transition defaults.

- Add glow box-shadows to live/processing (green) and blocked (red) status badges in `terminal-and-status.css`. Selected terminal header gains an inset top highlight for active depth.

- Upgrade `chrome-and-buttons.css`: nav chrome gets a subtle inset highlight; dropdown menus get a richer multi-layer box-shadow.

- Add error boundary panel styles to `foundation.css`.

## Prompts

- Extend `swarm-parent.md` with a **Timeout and Escalation Protocol** (5-step: ping → inspect → targeted guidance → ABORT → proceed with done work) and two additional failure modes (infinite waiting, taking over a worker's task).

## Dev tooling

- Add `scripts/dev-preview.sh` wrapper that exports the full nvm PATH before launching `node scripts/dev.mjs`, enabling the Claude preview server to start the full dev stack without PATH issues.