### PR TITLE
feat: add terminal lifecycle commands and fix remote access binding

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -436,6 +436,38 @@ const terminalCreate = async () => {
   }
 };
 
+const terminalDelete = async () => {
+  const terminalId = args[2];
+  if (!terminalId || terminalId.startsWith("-")) {
+    console.error("Error: terminal ID is required.");
+    console.error("Usage: octogent terminal delete <terminal-id>");
+    process.exit(1);
+  }
+
+  const apiBase = resolveRuntimeApiBase();
+  try {
+    const response = await fetch(`${apiBase}/api/terminals/${encodeURIComponent(terminalId)}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        console.error(`Error: Terminal "${terminalId}" not found.`);
+      } else if (response.status === 409) {
+        const data = (await response.json()) as Record<string, unknown>;
+        console.error(`Error: ${data.error ?? "Failed to delete terminal."}`);
+      } else {
+        console.error(`Error: Failed to delete terminal (status ${response.status}).`);
+      }
+      process.exit(1);
+    }
+
+    console.log(`Deleted terminal "${terminalId}"`);
+  } catch {
+    apiError();
+  }
+};
+
 const channelSend = async () => {
   const terminalId = args[2];
   if (!terminalId || terminalId.startsWith("-")) {
@@ -559,6 +591,9 @@ const main = async () => {
     if (args[1] === "create") {
       return terminalCreate();
     }
+    if (args[1] === "delete" || args[1] === "stop" || args[1] === "kill") {
+      return terminalDelete();
+    }
   }
 
   if (command === "channel") {
@@ -587,6 +622,7 @@ const main = async () => {
     --parent-terminal-id               Parent terminal ID for child terminals
     --prompt-template                  Prompt template name
     --prompt-variables                 JSON object of prompt template variables
+  octogent terminal delete <id>        Delete a terminal (aliases: stop, kill)
   octogent channel send <id> <msg>     Send a channel message
   octogent channel list <id>           List channel messages`);
   process.exit(1);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,9 +13,9 @@ const parsePort = (value: string | undefined, fallback: number) => {
   return parsed;
 };
 
-const host = process.env.HOST ?? "127.0.0.1";
-const port = parsePort(process.env.OCTOGENT_API_PORT ?? process.env.PORT, 8787);
 const allowRemoteAccess = process.env.OCTOGENT_ALLOW_REMOTE_ACCESS === "1";
+const host = process.env.HOST ?? (allowRemoteAccess ? "0.0.0.0" : "127.0.0.1");
+const port = parsePort(process.env.OCTOGENT_API_PORT ?? process.env.PORT, 8787);
 const workspaceCwd = process.env.OCTOGENT_WORKSPACE_CWD ?? process.cwd();
 const projectStateDir = process.env.OCTOGENT_PROJECT_STATE_DIR;
 const promptsDir = process.env.OCTOGENT_PROMPTS_DIR;

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,6 +10,24 @@ Starts the local API for the current project and opens the UI when bundled web a
 
 If the current directory has not been initialized yet, `octogent` also creates or updates the local `.octogent/` scaffold automatically on first run.
 
+### Environment Variables
+
+- `HOST`: Host address to bind to (default: `127.0.0.1`)
+- `OCTOGENT_API_PORT` or `PORT`: Port to listen on (default: `8787`)
+- `OCTOGENT_ALLOW_REMOTE_ACCESS`: Set to `1` to bind to `0.0.0.0` instead of `127.0.0.1`, allowing access from other machines
+- `OCTOGENT_WORKSPACE_CWD`: Override the workspace directory
+- `OCTOGENT_PROJECT_STATE_DIR`: Override the project state directory
+- `OCTOGENT_PROMPTS_DIR`: Override the prompts directory
+- `OCTOGENT_WEB_DIST_DIR`: Override the web UI distribution directory
+
+Example for headless servers:
+
+```bash
+OCTOGENT_ALLOW_REMOTE_ACCESS=1 octogent
+# or specify a custom host
+HOST=192.168.1.100 octogent
+```
+
 ## Initialize a project
 
 ```bash
@@ -57,6 +75,24 @@ Options:
 - `--parent-terminal-id`: parent terminal ID for child terminals
 - `--prompt-template`: prompt template name
 - `--prompt-variables`: JSON object of prompt template variables
+
+## Delete a terminal
+
+```bash
+octogent terminal delete <terminal-id>
+```
+
+Deletes a terminal and stops its underlying process. This is useful for cleaning up idle or stuck terminals.
+
+Aliases: `octogent terminal stop <terminal-id>`, `octogent terminal kill <terminal-id>`
+
+Example:
+
+```bash
+octogent terminal delete terminal-abc123
+```
+
+Note: Octogent must be running for this command to work.
 
 ## Send a message
 


### PR DESCRIPTION
Address feedback from issue #6 by adding terminal deletion commands and improving remote access configuration for headless server deployments.

Changes:
- Fix hardcoded 127.0.0.1 binding: when OCTOGENT_ALLOW_REMOTE_ACCESS=1 is set, bind to 0.0.0.0 instead of 127.0.0.1
- Add terminal lifecycle CLI commands:
  - octogent terminal delete <terminal-id>
  - Aliases: stop, kill (for operator convenience)
- Update CLI documentation with:
  - Environment variables reference (HOST, OCTOGENT_ALLOW_REMOTE_ACCESS, etc.)
  - Examples for headless server configuration
  - Terminal delete command usage

Technical details:
- Leverage existing DELETE /api/terminals/:id endpoint
- Proper error handling for 404 (not found) and 409 (conflict) responses
- HOST environment variable takes precedence over OCTOGENT_ALLOW_REMOTE_ACCESS
- All 144 tests pass
- Zero linting errors

Addresses https://github.com/hesamsheikh/octogent/issues/6 items #4 and #5