### PR TITLE
Fix `pnpm dev` on Windows: spawn EINVAL + URL pathname leading-slash

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
   - apps/*
   - packages/*
+
+onlyBuiltDependencies:
+  - node-pty
+  - esbuild
+  - "@biomejs/biome"

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const DEFAULT_START_PORT = 8787;
 const MAX_PORT_ATTEMPTS = 200;
@@ -77,7 +78,7 @@ const apiOrigin = `http://127.0.0.1:${apiPort}`;
 
 console.log(`[octogent-dev] using api port ${apiPort}`);
 
-const monorepoRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const monorepoRoot = fileURLToPath(new URL("..", import.meta.url)).replace(/[/\\]$/, "");
 
 // Resolve project state dir from global registry.
 const resolveProjectStateDir = (workspaceCwd) => {
@@ -126,6 +127,7 @@ const child = spawn(
   ["-r", "--parallel", "--filter", "@octogent/api", "--filter", "@octogent/web", "dev"],
   {
     stdio: "inherit",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OCTOGENT_API_PORT: String(apiPort),


### PR DESCRIPTION
## Summary

Two Windows-only bugs in `scripts/dev.mjs` block `pnpm dev` from booting on Win32. Both are one-line fixes; together they make a clean Windows install work end-to-end.

### 1. `spawn EINVAL` (errno -4071)

Node 20+ removed automatic shell-wrapping for `.cmd`/`.bat` files as part of the [CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980) mitigation. The current `spawn(pnpmCommand, ...)` call passes `pnpm.cmd` on Windows without `shell: true`, so Node refuses to launch it:

```
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:420:11)
    at file:///.../scripts/dev.mjs:124:15 {
  errno: -4071, code: 'EINVAL', syscall: 'spawn'
}
```

Args are hardcoded in this script (no user-controlled input), so `shell: true` is safe here.

### 2. `OCTOGENT_WORKSPACE_CWD does not exist`

`new URL("..", import.meta.url).pathname` returns `/C:/Users/...` (with a leading `/`) on Windows because URL pathnames are always rooted. The API server's `validateStartupEnv()` then rejects the workspace as nonexistent and exits 1:

```
apps/api dev: OCTOGENT_WORKSPACE_CWD directory does not exist: /C:/Users/.../octogent
```

Switched to `fileURLToPath()` from `node:url`, which produces a real Windows path. Behavior on macOS/Linux is unchanged.

### 3. (Bonus) pnpm 10 build-script approval

Added `onlyBuiltDependencies` to `pnpm-workspace.yaml` for `node-pty`, `esbuild`, and `@biomejs/biome` so pnpm 10 doesn't warn about ignored install scripts. `node-pty` ships prebuilds for `win32-x64` so no native compile is actually needed, but the entry suppresses the warning.

## Test plan

- [x] `pnpm install` succeeds on Windows 11 + Node 25 + pnpm 10
- [x] `pnpm dev` boots both `apps/api` (listening on 127.0.0.1:8787) and `apps/web` (Vite, http://localhost:5173 or next available)
- [x] `curl /api/deck/tentacles` returns `[]` (empty workspace, expected)
- [x] No regression on macOS — `fileURLToPath` and the `shell` flag are platform-conditional / cross-platform safe

Reproduction environment: Windows 11 Pro, Node v25.1.0, pnpm 10.33.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)