### PR TITLE
Make build scripts work with Corepack pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "pnpm dev",
     "dev": "node scripts/dev.mjs",
-    "build": "pnpm --filter @octogent/web build && pnpm --filter @octogent/web exec vite build --config vite.api.bundle.config.mts && node scripts/build-package.mjs",
+    "build": "node scripts/build.mjs",
     "smoke:public-install": "node scripts/smoke-public-install.mjs",
     "test": "pnpm -r test",
     "lint": "biome check .",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const formatCommand = (command, args) => [command, ...args].join(" ");
+
+const canRun = (command, args) => {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  return result.status === 0;
+};
+
+const resolvePnpmCommand = () => {
+  if (canRun("pnpm", ["--version"])) {
+    return { command: "pnpm", baseArgs: [] };
+  }
+
+  if (canRun("corepack", ["pnpm", "--version"])) {
+    return { command: "corepack", baseArgs: ["pnpm"] };
+  }
+
+  throw new Error(
+    "Unable to find pnpm. Install pnpm or enable Corepack for the packageManager field.",
+  );
+};
+
+const runChecked = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${formatCommand(command, args)}`);
+  }
+};
+
+const runPnpm = (pnpmCommand, args) => {
+  runChecked(pnpmCommand.command, [...pnpmCommand.baseArgs, ...args]);
+};
+
+const main = () => {
+  const pnpmCommand = resolvePnpmCommand();
+
+  runPnpm(pnpmCommand, ["--filter", "@octogent/web", "build"]);
+  runPnpm(pnpmCommand, [
+    "--filter",
+    "@octogent/web",
+    "exec",
+    "vite",
+    "build",
+    "--config",
+    "vite.api.bundle.config.mts",
+  ]);
+  runChecked(process.execPath, [join(repoRoot, "scripts", "build-package.mjs")]);
+};
+
+try {
+  main();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(String(error));
+  }
+  process.exitCode = 1;
+}

--- a/scripts/smoke-public-install.mjs
+++ b/scripts/smoke-public-install.mjs
@@ -96,7 +96,7 @@ const main = async () => {
     writeProviderStub();
 
     console.log("Building package artifacts...");
-    runChecked("pnpm", ["build"], {
+    runChecked(process.execPath, [join(repoRoot, "scripts", "build.mjs")], {
       cwd: repoRoot,
       env: process.env,
     });
@@ -124,11 +124,18 @@ const main = async () => {
       env: npmEnv,
     });
 
-    console.log("Launching packaged Octogent in a fresh workspace...");
     const octogentBin =
       process.platform === "win32"
         ? join(installDir, "node_modules", ".bin", "octogent.cmd")
         : join(installDir, "node_modules", ".bin", "octogent");
+
+    console.log("Initializing a fresh workspace with the packaged CLI...");
+    runChecked(octogentBin, ["init", "octogent-smoke"], {
+      cwd: workspaceDir,
+      env: runtimeEnv,
+    });
+
+    console.log("Launching packaged Octogent in the initialized workspace...");
 
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
Fixes #21.

## Summary

- replaces the root `build` shell chain with a Node build wrapper
- resolves pnpm from either a direct `pnpm` binary or `corepack pnpm`
- updates the public install smoke test to call the wrapper and initialize the fresh workspace before launch

## Validation

- `corepack pnpm exec biome check package.json scripts/build.mjs scripts/smoke-public-install.mjs`
- `corepack pnpm build`
- `corepack pnpm smoke:public-install`
- `corepack pnpm lint`
- `npx --yes pnpm@10.4.1 test`
