### PR TITLE
fix(dev): make pnpm dev work on Windows

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const DEFAULT_START_PORT = 8787;
 const MAX_PORT_ATTEMPTS = 200;
@@ -77,7 +78,9 @@ const apiOrigin = `http://127.0.0.1:${apiPort}`;
 
 console.log(`[octogent-dev] using api port ${apiPort}`);
 
-const monorepoRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+// fileURLToPath decodes percent-escapes (e.g. spaces) and yields a native path.
+// Using `.pathname` directly breaks on Windows and on any path containing spaces.
+const monorepoRoot = fileURLToPath(new URL("..", import.meta.url)).replace(/[/\\]$/, "");
 
 // Resolve project state dir from global registry.
 const resolveProjectStateDir = (workspaceCwd) => {
@@ -126,6 +129,9 @@ const child = spawn(
   ["-r", "--parallel", "--filter", "@octogent/api", "--filter", "@octogent/web", "dev"],
   {
     stdio: "inherit",
+    // On Windows, Node >= 20.12 refuses to spawn .cmd/.bat files (EINVAL) unless
+    // a shell is used (security fix for CVE-2024-27980). pnpm resolves to pnpm.cmd.
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OCTOGENT_API_PORT: String(apiPort),


### PR DESCRIPTION
Two Windows-specific bugs in scripts/dev.mjs prevented `pnpm dev` from
starting the API and web apps:

1. spawn EINVAL: Node >= 20.12 refuses to spawn .cmd/.bat files without a
   shell (CVE-2024-27980 hardening). pnpm resolves to pnpm.cmd on Windows,
   so the orchestrator crashed before launching anything. Pass
   shell: true on win32.

2. Invalid monorepo root path: new URL("..", import.meta.url).pathname
   yields a leading-slash, percent-encoded path on Windows
   (e.g. /C:/Users/Lucas%20Assis/.../octogent), so the API aborted with
   "directory does not exist" whenever the path contained a space. Use
   fileURLToPath to get a decoded native path.

Verified: pnpm dev now boots both the API and the Vite web server on
Windows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
