### PR TITLE
Add Codex provider setup selection

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -3,6 +3,8 @@ import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { basename, join, resolve } from "node:path";
 
+import { isTerminalAgentProvider } from "@octogent/core";
+
 import {
   ensureOctogentGitignoreEntry,
   ensureProjectScaffold,
@@ -14,6 +16,7 @@ import {
   resolveProjectStateDir,
 } from "./projectPersistence";
 import { clearRuntimeMetadata, readRuntimeMetadata, writeRuntimeMetadata } from "./runtimeMetadata";
+import { setDefaultAgentProvider } from "./setupState";
 import {
   collectStartupPrerequisiteReport,
   formatStartupPrerequisiteReport,
@@ -59,7 +62,11 @@ const resolveRuntimeAssetPath = (...relativePathCandidates: [string[], ...string
 const DEFAULT_START_PORT = 8787;
 const MAX_PORT_ATTEMPTS = 200;
 
-const initializeProject = (workspaceCwd: string, preferredName?: string) => {
+const initializeProject = (
+  workspaceCwd: string,
+  preferredName?: string,
+  defaultAgentProvider?: "codex" | "claude-code",
+) => {
   const projectName = preferredName?.trim() || basename(workspaceCwd) || "octogent-project";
   const hadConfig = loadProjectConfig(workspaceCwd) !== null;
   const projectConfig = ensureProjectScaffold(workspaceCwd, projectName);
@@ -67,6 +74,9 @@ const initializeProject = (workspaceCwd: string, preferredName?: string) => {
   registerProject(workspaceCwd, projectConfig.displayName);
   const projectStateDir = resolveProjectStateDir(workspaceCwd, projectConfig.displayName);
   migrateStateToGlobal(workspaceCwd, projectStateDir);
+  if (defaultAgentProvider) {
+    setDefaultAgentProvider(projectStateDir, defaultAgentProvider);
+  }
   return {
     created: !hadConfig,
     projectConfig,
@@ -96,15 +106,51 @@ const resolveStartupProjectContext = (workspaceCwd: string) => {
   };
 };
 
-const initProject = (name?: string) => {
+const parseInitProjectName = () => {
+  const providerIndex = args.indexOf("--provider");
+  const rawName = args[1];
+  if (!rawName || rawName === "--provider") {
+    return undefined;
+  }
+
+  if (providerIndex === 1 || providerIndex === 2) {
+    return providerIndex === 1 ? undefined : rawName;
+  }
+
+  return rawName.startsWith("-") ? undefined : rawName;
+};
+
+const parseProviderFlag = () => {
+  const rawProvider = parseFlag("--provider");
+  if (rawProvider === undefined) {
+    return undefined;
+  }
+
+  if (!isTerminalAgentProvider(rawProvider)) {
+    console.error("Error: --provider must be either 'codex' or 'claude-code'.");
+    process.exit(1);
+  }
+
+  return rawProvider;
+};
+
+const initProject = () => {
   const projectPath = process.cwd();
-  const { created, projectConfig, projectStateDir } = initializeProject(projectPath, name);
+  const defaultAgentProvider = parseProviderFlag();
+  const { created, projectConfig, projectStateDir } = initializeProject(
+    projectPath,
+    parseInitProjectName(),
+    defaultAgentProvider,
+  );
 
   console.log(
     `${created ? "Initialized" : "Updated"} Octogent project "${projectConfig.displayName}" at ${projectPath}`,
   );
   console.log("  .octogent/ directory ready (project metadata, tentacles, worktrees)");
   console.log(`  Global state: ${projectStateDir}`);
+  if (defaultAgentProvider) {
+    console.log(`  Default provider: ${defaultAgentProvider}`);
+  }
   console.log("  .gitignore updated");
   console.log("\nRun `octogent` to start the dashboard.");
 };
@@ -404,6 +450,7 @@ const terminalCreate = async () => {
   const autoRenamePromptContext = parseFlag("--auto-rename-prompt-context");
   const promptTemplate = parseFlag("--prompt-template");
   const promptVariables = parseJsonFlag("--prompt-variables");
+  const agentProvider = parseProviderFlag();
   const apiBase = resolveRuntimeApiBase();
 
   const body: Record<string, unknown> = {};
@@ -418,6 +465,7 @@ const terminalCreate = async () => {
   if (autoRenamePromptContext) body.autoRenamePromptContext = autoRenamePromptContext;
   if (promptTemplate) body.promptTemplate = promptTemplate;
   if (promptVariables) body.promptVariables = promptVariables;
+  if (agentProvider) body.agentProvider = agentProvider;
 
   try {
     const response = await fetch(`${apiBase}/api/terminals`, {
@@ -615,7 +663,7 @@ const main = async () => {
   }
 
   if (command === "init") {
-    return initProject(args[1]);
+    return initProject();
   }
 
   if (command === "projects" || command === "project") {
@@ -672,6 +720,7 @@ const main = async () => {
   console.log(`Usage:
   octogent                             Start the dashboard in the current project
   octogent init [project-name]         Initialize the current directory explicitly
+    --provider                         codex | claude-code
   octogent projects                    List registered projects
 
   octogent tentacle create <name>      Create a tentacle (Octogent must be running)
@@ -686,6 +735,7 @@ const main = async () => {
     --parent-terminal-id               Parent terminal ID for child terminals
     --prompt-template                  Prompt template name
     --prompt-variables                 JSON object of prompt template variables
+    --provider                         codex | claude-code
   octogent terminal list               List terminal lifecycle state
   octogent terminal stop <id>          Stop a terminal session
   octogent terminal kill <id>          Kill a terminal session or recorded process

--- a/apps/api/src/createApiServer.ts
+++ b/apps/api/src/createApiServer.ts
@@ -16,6 +16,7 @@ import type { CreateApiServerOptions } from "./createApiServer/types";
 import { createUpgradeHandler } from "./createApiServer/upgradeHandler";
 import { readGithubRepoSummary as readGithubRepoSummaryDefault } from "./githubRepoSummary";
 import { createMonitorService } from "./monitor";
+import { resolveDefaultAgentProvider } from "./setupStatus";
 import { createTerminalRuntime } from "./terminalRuntime";
 
 export const createApiServer = ({
@@ -97,6 +98,8 @@ export const createApiServer = ({
     workspaceCwd: resolvedWorkspaceCwd,
     projectStateDir: resolvedStateDir,
     getApiBaseUrl,
+    getDefaultAgentProvider: () =>
+      resolveDefaultAgentProvider(resolvedStateDir).defaultAgentProvider,
   };
   if (gitClient) {
     runtimeOptions.gitClient = gitClient;

--- a/apps/api/src/createApiServer/miscRoutes.ts
+++ b/apps/api/src/createApiServer/miscRoutes.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceSetupStepId } from "@octogent/core";
+import { type WorkspaceSetupStepId, isTerminalAgentProvider } from "@octogent/core";
 
 import {
   deleteUserPrompt,
@@ -12,6 +12,7 @@ import {
   ensureWorkspaceGitignore,
   initializeWorkspaceFiles,
   readWorkspaceSetupSnapshot,
+  setDefaultAgentProvider,
 } from "../setupStatus";
 import type { ApiRouteHandler } from "./routeHelpers";
 import {
@@ -28,6 +29,7 @@ const WORKSPACE_SETUP_STEP_PATH_PATTERN = /^\/api\/setup\/steps\/([^/]+)$/;
 const isWorkspaceSetupStepId = (value: string): value is WorkspaceSetupStepId =>
   value === "initialize-workspace" ||
   value === "ensure-gitignore" ||
+  value === "check-codex" ||
   value === "check-claude" ||
   value === "check-git" ||
   value === "check-curl" ||
@@ -38,13 +40,52 @@ export const handleWorkspaceSetupRoute: ApiRouteHandler = async (
   { workspaceCwd, projectStateDir },
 ) => {
   if (requestUrl.pathname === WORKSPACE_SETUP_PATH) {
+    if (request.method === "GET") {
+      writeJson(
+        response,
+        200,
+        readWorkspaceSetupSnapshot(workspaceCwd, projectStateDir),
+        corsOrigin,
+      );
+      return true;
+    }
+
+    if (request.method === "PATCH") {
+      const bodyReadResult = await readJsonBodyOrWriteError(request, response, corsOrigin);
+      if (!bodyReadResult.ok) {
+        return true;
+      }
+
+      const payload = bodyReadResult.payload;
+      const rawDefaultAgentProvider =
+        payload && typeof payload === "object" && !Array.isArray(payload)
+          ? (payload as Record<string, unknown>).defaultAgentProvider
+          : undefined;
+
+      if (!isTerminalAgentProvider(rawDefaultAgentProvider)) {
+        writeJson(
+          response,
+          400,
+          { error: "defaultAgentProvider must be either 'codex' or 'claude-code'." },
+          corsOrigin,
+        );
+        return true;
+      }
+
+      setDefaultAgentProvider(projectStateDir, rawDefaultAgentProvider);
+      writeJson(
+        response,
+        200,
+        readWorkspaceSetupSnapshot(workspaceCwd, projectStateDir),
+        corsOrigin,
+      );
+      return true;
+    }
+
     if (request.method !== "GET") {
       writeMethodNotAllowed(response, corsOrigin);
       return true;
     }
-
-    writeJson(response, 200, readWorkspaceSetupSnapshot(workspaceCwd, projectStateDir), corsOrigin);
-    return true;
   }
 
   const match = requestUrl.pathname.match(WORKSPACE_SETUP_STEP_PATH_PATTERN);
@@ -67,7 +108,12 @@ export const handleWorkspaceSetupRoute: ApiRouteHandler = async (
     initializeWorkspaceFiles(workspaceCwd, projectStateDir);
   } else if (stepId === "ensure-gitignore") {
     ensureWorkspaceGitignore(workspaceCwd);
-  } else if (stepId === "check-claude" || stepId === "check-git" || stepId === "check-curl") {
+  } else if (
+    stepId === "check-codex" ||
+    stepId === "check-claude" ||
+    stepId === "check-git" ||
+    stepId === "check-curl"
+  ) {
     markSetupStepVerified(projectStateDir, stepId);
   }
 

--- a/apps/api/src/setupState.ts
+++ b/apps/api/src/setupState.ts
@@ -1,14 +1,19 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { WorkspaceSetupStepId } from "@octogent/core";
+import {
+  type TerminalAgentProvider,
+  type WorkspaceSetupStepId,
+  isTerminalAgentProvider,
+} from "@octogent/core";
 
 const SETUP_STATE_RELATIVE_PATH = join("state", "setup.json");
-const VERIFIED_SETUP_STEP_IDS = ["check-claude", "check-git", "check-curl"] as const;
+const VERIFIED_SETUP_STEP_IDS = ["check-codex", "check-claude", "check-git", "check-curl"] as const;
 
 type VerifiedSetupStepId = (typeof VERIFIED_SETUP_STEP_IDS)[number];
 
 export type SetupState = {
   version: 1;
+  defaultAgentProvider?: TerminalAgentProvider;
   tentaclesInitializedAt?: string;
   verifiedSteps?: Partial<Record<VerifiedSetupStepId, string>>;
 };
@@ -37,6 +42,9 @@ export const readSetupState = (stateDir: string): SetupState => {
 
     return {
       version: 1,
+      ...(isTerminalAgentProvider(raw.defaultAgentProvider)
+        ? { defaultAgentProvider: raw.defaultAgentProvider }
+        : {}),
       ...(typeof raw.tentaclesInitializedAt === "string"
         ? { tentaclesInitializedAt: raw.tentaclesInitializedAt }
         : {}),
@@ -50,6 +58,17 @@ export const readSetupState = (stateDir: string): SetupState => {
 export const writeSetupState = (stateDir: string, state: SetupState) => {
   mkdirSync(join(stateDir, "state"), { recursive: true });
   writeFileSync(join(stateDir, SETUP_STATE_RELATIVE_PATH), `${JSON.stringify(state, null, 2)}\n`);
+};
+
+export const setDefaultAgentProvider = (
+  stateDir: string,
+  defaultAgentProvider: TerminalAgentProvider,
+) => {
+  const currentState = readSetupState(stateDir);
+  writeSetupState(stateDir, {
+    ...currentState,
+    defaultAgentProvider,
+  });
 };
 
 export const markSetupStepVerified = (stateDir: string, stepId: WorkspaceSetupStepId) => {

--- a/apps/api/src/setupStatus.ts
+++ b/apps/api/src/setupStatus.ts
@@ -1,7 +1,12 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
-import type { WorkspaceSetupSnapshot, WorkspaceSetupStep } from "@octogent/core";
+import type {
+  TerminalAgentProvider,
+  WorkspaceSetupProviderChoice,
+  WorkspaceSetupSnapshot,
+  WorkspaceSetupStep,
+} from "@octogent/core";
 
 import { readDeckTentacles } from "./deck/readDeckTentacles";
 import {
@@ -13,10 +18,55 @@ import {
   migrateStateToGlobal,
   registerProject,
 } from "./projectPersistence";
-import { readSetupState } from "./setupState";
+import { readSetupState, setDefaultAgentProvider } from "./setupState";
 import { collectStartupPrerequisiteReport } from "./startupPrerequisites";
 
-export const initializeWorkspaceFiles = (workspaceCwd: string, projectStateDir: string) => {
+const PROVIDER_LABELS: Record<TerminalAgentProvider, string> = {
+  codex: "Codex",
+  "claude-code": "Claude Code",
+};
+
+export const resolveDefaultAgentProvider = (
+  projectStateDir: string,
+  availability = collectStartupPrerequisiteReport().availability,
+): {
+  defaultAgentProvider: TerminalAgentProvider;
+  configuredAgentProvider: TerminalAgentProvider | null;
+  needsProviderSelection: boolean;
+  providerChoices: WorkspaceSetupProviderChoice[];
+} => {
+  const setupState = readSetupState(projectStateDir);
+  const configuredAgentProvider = setupState.defaultAgentProvider ?? null;
+  const availableProviders: TerminalAgentProvider[] = [];
+  if (availability.codex) availableProviders.push("codex");
+  if (availability.claude) availableProviders.push("claude-code");
+
+  const autoSelectedProvider: TerminalAgentProvider =
+    availableProviders.length === 1 && availableProviders[0]
+      ? availableProviders[0]
+      : "claude-code";
+  const defaultAgentProvider = configuredAgentProvider ?? autoSelectedProvider;
+  const needsProviderSelection =
+    configuredAgentProvider === null && availability.codex && availability.claude;
+
+  return {
+    defaultAgentProvider,
+    configuredAgentProvider,
+    needsProviderSelection,
+    providerChoices: (["claude-code", "codex"] as TerminalAgentProvider[]).map((provider) => ({
+      provider,
+      label: PROVIDER_LABELS[provider],
+      available: provider === "codex" ? availability.codex : availability.claude,
+      selected: provider === defaultAgentProvider,
+    })),
+  };
+};
+
+export const initializeWorkspaceFiles = (
+  workspaceCwd: string,
+  projectStateDir: string,
+  defaultAgentProvider?: TerminalAgentProvider,
+) => {
   const projectName = loadProjectConfig(workspaceCwd)?.displayName;
   const projectConfig = ensureProjectScaffold(
     workspaceCwd,
@@ -26,6 +76,9 @@ export const initializeWorkspaceFiles = (workspaceCwd: string, projectStateDir: 
   registerProject(workspaceCwd, projectConfig.displayName);
   mkdirSync(join(projectStateDir, "state"), { recursive: true });
   migrateStateToGlobal(workspaceCwd, projectStateDir);
+  if (defaultAgentProvider) {
+    setDefaultAgentProvider(projectStateDir, defaultAgentProvider);
+  }
 
   return { projectConfig, projectStateDir };
 };
@@ -52,12 +105,63 @@ export const readWorkspaceSetupSnapshot = (
   const setupState = readSetupState(projectStateDir);
   const isFirstRun = !hasAnyTentacles && !setupState.tentaclesInitializedAt;
   const verifiedSteps = setupState.verifiedSteps ?? {};
+  const isCodexVerified = Boolean(verifiedSteps["check-codex"]);
   const isClaudeVerified = Boolean(verifiedSteps["check-claude"]);
   const isGitVerified = Boolean(verifiedSteps["check-git"]);
   const isCurlVerified = Boolean(verifiedSteps["check-curl"]);
+  const hasCodex = prerequisites.availability.codex;
   const hasClaudeCode = prerequisites.availability.claude;
   const hasGit = prerequisites.availability.git;
   const hasCurl = prerequisites.availability.curl;
+  const providerResolution = resolveDefaultAgentProvider(
+    projectStateDir,
+    prerequisites.availability,
+  );
+
+  const codexStep: WorkspaceSetupStep = {
+    id: "check-codex",
+    title: "Check Codex",
+    description: "Verify the Codex workflow is available on this machine.",
+    complete: hasCodex && isCodexVerified,
+    required: providerResolution.defaultAgentProvider === "codex",
+    actionLabel: "Check Codex",
+    statusText: hasCodex
+      ? isCodexVerified
+        ? "Codex is available."
+        : "Confirm Codex before using it as the planner."
+      : "Codex is unavailable.",
+    guidance: hasCodex
+      ? isCodexVerified
+        ? null
+        : "Click to verify the Codex workflow on this machine."
+      : "Install Codex and run `codex login` before using Codex terminals.",
+    command: hasCodex ? null : "codex login",
+  };
+
+  const claudeStep: WorkspaceSetupStep = {
+    id: "check-claude",
+    title: "Check Claude Code",
+    description: "Verify the Claude Code workflow is available on this machine.",
+    complete: hasClaudeCode && isClaudeVerified,
+    required: providerResolution.defaultAgentProvider === "claude-code",
+    actionLabel: "Check Claude Code",
+    statusText: hasClaudeCode
+      ? isClaudeVerified
+        ? "Claude Code is available."
+        : "Confirm Claude Code before using it as the planner."
+      : "Claude Code is unavailable.",
+    guidance: hasClaudeCode
+      ? isClaudeVerified
+        ? null
+        : "Click to verify the Claude Code workflow on this machine."
+      : "Install Claude Code and log in before using Claude terminals.",
+    command: hasClaudeCode ? null : "claude login",
+  };
+
+  const providerSteps =
+    providerResolution.defaultAgentProvider === "codex"
+      ? [codexStep, claudeStep]
+      : [claudeStep, codexStep];
 
   const steps: WorkspaceSetupStep[] = [
     {
@@ -90,25 +194,7 @@ export const readWorkspaceSetupSnapshot = (
         : "Git ignore entry is missing. Create or update .gitignore with the Octogent workspace path.",
       command: hasGitignore ? null : "printf '.octogent\\n' >> .gitignore",
     },
-    {
-      id: "check-claude",
-      title: "Check Claude Code",
-      description: "Verify the default Claude Code workflow is available on this machine.",
-      complete: hasClaudeCode && isClaudeVerified,
-      required: false,
-      actionLabel: "Check Claude Code",
-      statusText: hasClaudeCode
-        ? isClaudeVerified
-          ? "Claude Code is available."
-          : "Confirm Claude Code before using the planner."
-        : "Claude Code is unavailable.",
-      guidance: hasClaudeCode
-        ? isClaudeVerified
-          ? null
-          : "Click to verify the Claude Code workflow on this machine."
-        : "Install Claude Code and log in before using the default Claude workflow.",
-      command: hasClaudeCode ? null : "claude login",
-    },
+    ...providerSteps,
     {
       id: "check-git",
       title: "Check Git",
@@ -167,8 +253,14 @@ export const readWorkspaceSetupSnapshot = (
   return {
     isFirstRun,
     shouldShowSetupCard: isFirstRun || (!hasAnyTentacles && (!hasProjectScaffold || !hasGitignore)),
+    defaultAgentProvider: providerResolution.defaultAgentProvider,
+    configuredAgentProvider: providerResolution.configuredAgentProvider,
+    needsProviderSelection: providerResolution.needsProviderSelection,
+    providerChoices: providerResolution.providerChoices,
     hasAnyTentacles,
     tentacleCount,
     steps,
   };
 };
+
+export { setDefaultAgentProvider };

--- a/apps/api/src/terminalRuntime.ts
+++ b/apps/api/src/terminalRuntime.ts
@@ -63,6 +63,7 @@ export const createTerminalRuntime = ({
   projectStateDir,
   gitClient = createDefaultGitClient(),
   getApiBaseUrl = () => process.env.OCTOGENT_API_ORIGIN ?? "http://127.0.0.1:8787",
+  getDefaultAgentProvider = () => DEFAULT_AGENT_PROVIDER,
   maxConcurrentSessions,
 }: CreateTerminalRuntimeOptions) => {
   const stateDir = projectStateDir ?? join(workspaceCwd, ".octogent");
@@ -457,7 +458,7 @@ export const createTerminalRuntime = ({
       ...(autoRenamePromptContext ? { autoRenamePromptContext } : {}),
       createdAt: new Date().toISOString(),
       workspaceMode,
-      agentProvider: agentProvider ?? DEFAULT_AGENT_PROVIDER,
+      agentProvider: agentProvider ?? getDefaultAgentProvider(),
       lifecycleState: "registered",
       lifecycleUpdatedAt: new Date().toISOString(),
       ...(initialPrompt ? { initialPrompt } : {}),

--- a/apps/api/src/terminalRuntime/types.ts
+++ b/apps/api/src/terminalRuntime/types.ts
@@ -189,5 +189,6 @@ export type CreateTerminalRuntimeOptions = {
   projectStateDir?: string | undefined;
   gitClient?: GitClient;
   getApiBaseUrl?: () => string;
+  getDefaultAgentProvider?: () => TerminalAgentProvider;
   maxConcurrentSessions?: number | undefined;
 };

--- a/apps/api/tests/providerDefault.test.ts
+++ b/apps/api/tests/providerDefault.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { setDefaultAgentProvider } from "../src/setupState";
+import { resolveDefaultAgentProvider } from "../src/setupStatus";
+
+const availability = (
+  overrides: Partial<Record<"claude" | "codex" | "git" | "gh" | "curl", boolean>>,
+) => ({
+  claude: false,
+  codex: false,
+  git: false,
+  gh: false,
+  curl: false,
+  ...overrides,
+});
+
+describe("default agent provider resolution", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const createStateDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), "octogent-provider-"));
+    tempDirs.push(dir);
+    return dir;
+  };
+
+  it("auto-selects Codex when it is the only available provider", () => {
+    const stateDir = createStateDir();
+
+    const result = resolveDefaultAgentProvider(stateDir, availability({ codex: true }));
+
+    expect(result.defaultAgentProvider).toBe("codex");
+    expect(result.configuredAgentProvider).toBeNull();
+    expect(result.needsProviderSelection).toBe(false);
+  });
+
+  it("requires explicit selection when both providers are available", () => {
+    const stateDir = createStateDir();
+
+    const result = resolveDefaultAgentProvider(
+      stateDir,
+      availability({ claude: true, codex: true }),
+    );
+
+    expect(result.defaultAgentProvider).toBe("claude-code");
+    expect(result.configuredAgentProvider).toBeNull();
+    expect(result.needsProviderSelection).toBe(true);
+  });
+
+  it("uses a persisted provider selection over availability defaults", () => {
+    const stateDir = createStateDir();
+    setDefaultAgentProvider(stateDir, "codex");
+
+    const result = resolveDefaultAgentProvider(
+      stateDir,
+      availability({ claude: true, codex: true }),
+    );
+
+    expect(result.defaultAgentProvider).toBe("codex");
+    expect(result.configuredAgentProvider).toBe("codex");
+    expect(result.needsProviderSelection).toBe(false);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,9 @@
-import { type TerminalSnapshot, buildTerminalList, isAgentRuntimeState } from "@octogent/core";
+import {
+  type TerminalSnapshot,
+  type WorkspaceSetupStepId,
+  buildTerminalList,
+  isAgentRuntimeState,
+} from "@octogent/core";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 
 import { useBackendLivenessPolling } from "./app/hooks/useBackendLivenessPolling";
@@ -103,16 +108,10 @@ export const App = () => {
     workspaceSetupError,
     refreshWorkspaceSetup,
     runWorkspaceSetupStep,
+    setDefaultAgentProvider,
   } = useWorkspaceSetup();
-  const [runningWorkspaceSetupStepId, setRunningWorkspaceSetupStepId] = useState<
-    | "initialize-workspace"
-    | "ensure-gitignore"
-    | "check-claude"
-    | "check-git"
-    | "check-curl"
-    | "create-tentacles"
-    | null
-  >(null);
+  const [runningWorkspaceSetupStepId, setRunningWorkspaceSetupStepId] =
+    useState<WorkspaceSetupStepId | null>(null);
 
   const readColumns = useCallback(
     async (signal?: AbortSignal) => {
@@ -398,15 +397,7 @@ export const App = () => {
   }, []);
 
   const handleRunWorkspaceSetupStep = useCallback(
-    async (
-      stepId:
-        | "initialize-workspace"
-        | "ensure-gitignore"
-        | "check-claude"
-        | "check-git"
-        | "check-curl"
-        | "create-tentacles",
-    ) => {
+    async (stepId: WorkspaceSetupStepId) => {
       setRunningWorkspaceSetupStepId(stepId);
       try {
         await runWorkspaceSetupStep(stepId);
@@ -471,6 +462,7 @@ export const App = () => {
               workspaceSetupError,
               onRefreshWorkspaceSetup: refreshWorkspaceSetup,
               onRunWorkspaceSetupStep: runWorkspaceSetupStep,
+              onSetDefaultAgentProvider: setDefaultAgentProvider,
               suppressWorkspaceSetupCard: true,
             }}
             isMonitorVisible={isMonitorVisible}
@@ -522,6 +514,7 @@ export const App = () => {
               workspaceSetupError,
               runningWorkspaceSetupStepId,
               onRunWorkspaceSetupStep: handleRunWorkspaceSetupStep,
+              onSetDefaultAgentProvider: setDefaultAgentProvider,
               onLaunchWorkspaceSetupPlanner: async () => {
                 const response = await fetch("/api/terminals", {
                   method: "POST",
@@ -529,7 +522,6 @@ export const App = () => {
                   body: JSON.stringify({
                     name: "tentacle-planner",
                     workspaceMode: "shared",
-                    agentProvider: "claude-code",
                     promptTemplate: "tentacle-planner",
                   }),
                 });

--- a/apps/web/src/app/hooks/useTerminalMutations.ts
+++ b/apps/web/src/app/hooks/useTerminalMutations.ts
@@ -130,7 +130,7 @@ export const useTerminalMutations = ({
           },
           body: JSON.stringify({
             workspaceMode,
-            agentProvider: agentProvider ?? "claude-code",
+            ...(agentProvider ? { agentProvider } : {}),
             ...(tentacleId ? { tentacleId } : {}),
           }),
         });

--- a/apps/web/src/app/hooks/useWorkspaceSetup.ts
+++ b/apps/web/src/app/hooks/useWorkspaceSetup.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceSetupSnapshot, WorkspaceSetupStepId } from "@octogent/core";
+import type {
+  TerminalAgentProvider,
+  WorkspaceSetupSnapshot,
+  WorkspaceSetupStepId,
+} from "@octogent/core";
 import { useCallback, useEffect, useState } from "react";
 
 import { buildWorkspaceSetupStepUrl, buildWorkspaceSetupUrl } from "../../runtime/runtimeEndpoints";
@@ -9,6 +13,9 @@ type UseWorkspaceSetupResult = {
   workspaceSetupError: string | null;
   refreshWorkspaceSetup: () => Promise<WorkspaceSetupSnapshot | null>;
   runWorkspaceSetupStep: (stepId: WorkspaceSetupStepId) => Promise<WorkspaceSetupSnapshot | null>;
+  setDefaultAgentProvider: (
+    defaultAgentProvider: TerminalAgentProvider,
+  ) => Promise<WorkspaceSetupSnapshot | null>;
 };
 
 const readErrorMessage = async (response: Response, fallback: string) => {
@@ -66,6 +73,33 @@ export const useWorkspaceSetup = (): UseWorkspaceSetupResult => {
     }
   }, []);
 
+  const setDefaultAgentProvider = useCallback(
+    async (defaultAgentProvider: TerminalAgentProvider) => {
+      try {
+        setWorkspaceSetupError(null);
+        const response = await fetch(buildWorkspaceSetupUrl(), {
+          method: "PATCH",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ defaultAgentProvider }),
+        });
+        if (!response.ok) {
+          throw new Error(await readErrorMessage(response, "Unable to update provider."));
+        }
+        const payload = (await response.json()) as WorkspaceSetupSnapshot;
+        setWorkspaceSetup(payload);
+        return payload;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to update provider.";
+        setWorkspaceSetupError(message);
+        return null;
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     void refreshWorkspaceSetup();
   }, [refreshWorkspaceSetup]);
@@ -76,5 +110,6 @@ export const useWorkspaceSetup = (): UseWorkspaceSetupResult => {
     workspaceSetupError,
     refreshWorkspaceSetup,
     runWorkspaceSetupStep,
+    setDefaultAgentProvider,
   };
 };

--- a/apps/web/src/components/CanvasPrimaryView.tsx
+++ b/apps/web/src/components/CanvasPrimaryView.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { WorkspaceSetupSnapshot, WorkspaceSetupStepId } from "@octogent/core";
+import type {
+  TerminalAgentProvider,
+  WorkspaceSetupSnapshot,
+  WorkspaceSetupStepId,
+} from "@octogent/core";
 import {
   Check as CheckIcon,
   ChevronDown,
@@ -63,6 +67,9 @@ type CanvasPrimaryViewProps = {
   workspaceSetupError?: string | null;
   runningWorkspaceSetupStepId?: WorkspaceSetupStepId | null;
   onRunWorkspaceSetupStep?: (stepId: WorkspaceSetupStepId) => Promise<void> | void;
+  onSetDefaultAgentProvider?: (
+    defaultAgentProvider: TerminalAgentProvider,
+  ) => Promise<WorkspaceSetupSnapshot | null>;
   onLaunchWorkspaceSetupPlanner?: () => Promise<string | undefined> | undefined;
   recentlyCreatedTerminal?: TerminalView[number] | null;
   onCanvasOpenTerminalIdsChange?: (ids: string[]) => void;
@@ -201,6 +208,7 @@ export const CanvasPrimaryView = ({
   workspaceSetupError = null,
   runningWorkspaceSetupStepId = null,
   onRunWorkspaceSetupStep,
+  onSetDefaultAgentProvider,
   onLaunchWorkspaceSetupPlanner,
   recentlyCreatedTerminal,
   onCanvasOpenTerminalIdsChange,
@@ -1197,7 +1205,10 @@ export const CanvasPrimaryView = ({
               onRunStep={(stepId) => {
                 void onRunWorkspaceSetupStep?.(stepId);
               }}
-              onLaunchClaudeCode={() => {
+              onSelectProvider={(provider) => {
+                void onSetDefaultAgentProvider?.(provider);
+              }}
+              onLaunchAgent={() => {
                 void handleLaunchWorkspaceSetupPlanner();
               }}
               isLaunchingAgent={isLaunchingWorkspaceSetupPlanner}

--- a/apps/web/src/components/DeckPrimaryView.tsx
+++ b/apps/web/src/components/DeckPrimaryView.tsx
@@ -58,6 +58,9 @@ type DeckPrimaryViewProps = {
   workspaceSetupError: string | null;
   onRefreshWorkspaceSetup: () => Promise<WorkspaceSetupSnapshot | null>;
   onRunWorkspaceSetupStep: (stepId: WorkspaceSetupStepId) => Promise<WorkspaceSetupSnapshot | null>;
+  onSetDefaultAgentProvider: (
+    defaultAgentProvider: TerminalAgentProvider,
+  ) => Promise<WorkspaceSetupSnapshot | null>;
   suppressWorkspaceSetupCard?: boolean;
 };
 
@@ -68,6 +71,7 @@ export const DeckPrimaryView = ({
   workspaceSetupError,
   onRefreshWorkspaceSetup,
   onRunWorkspaceSetupStep,
+  onSetDefaultAgentProvider,
   suppressWorkspaceSetupCard = false,
 }: DeckPrimaryViewProps) => {
   const [tentacles, setTentacles] = useState<DeckTentacleSummary[]>([]);
@@ -80,19 +84,13 @@ export const DeckPrimaryView = ({
   const [availableSkills, setAvailableSkills] = useState<DeckAvailableSkill[]>([]);
   const [savingTentacleSkillsId, setSavingTentacleSkillsId] = useState<string | null>(null);
 
-  const [selectedAgent, setSelectedAgent] = useState<TerminalAgentProvider>("claude-code");
+  const [selectedAgent, setSelectedAgent] = useState<TerminalAgentProvider>(
+    workspaceSetup?.defaultAgentProvider ?? "claude-code",
+  );
   const [agentMenuOpen, setAgentMenuOpen] = useState(false);
   const agentMenuRef = useRef<HTMLDivElement>(null);
   const [isLaunchingAgent, setIsLaunchingAgent] = useState(false);
-  const [runningSetupStepId, setRunningSetupStepId] = useState<
-    | "initialize-workspace"
-    | "ensure-gitignore"
-    | "check-claude"
-    | "check-git"
-    | "check-curl"
-    | "create-tentacles"
-    | null
-  >(null);
+  const [runningSetupStepId, setRunningSetupStepId] = useState<WorkspaceSetupStepId | null>(null);
 
   // Fetch tentacle list
   const fetchTentacles = useCallback(async () => {
@@ -112,6 +110,12 @@ export const DeckPrimaryView = ({
   useEffect(() => {
     void fetchTentacles();
   }, [fetchTentacles]);
+
+  useEffect(() => {
+    if (workspaceSetup?.defaultAgentProvider) {
+      setSelectedAgent(workspaceSetup.defaultAgentProvider);
+    }
+  }, [workspaceSetup?.defaultAgentProvider]);
 
   useEffect(() => {
     let cancelled = false;
@@ -226,15 +230,7 @@ export const DeckPrimaryView = ({
   }, [selectedAgent, fetchTentacles]);
 
   const handleRunSetupStep = useCallback(
-    async (
-      stepId:
-        | "initialize-workspace"
-        | "ensure-gitignore"
-        | "check-claude"
-        | "check-git"
-        | "check-curl"
-        | "create-tentacles",
-    ) => {
+    async (stepId: WorkspaceSetupStepId) => {
       setRunningSetupStepId(stepId);
       try {
         await onRunWorkspaceSetupStep(stepId);
@@ -362,7 +358,11 @@ export const DeckPrimaryView = ({
                 isLoading={isWorkspaceSetupLoading}
                 error={workspaceSetupError}
                 onRunStep={handleRunSetupStep}
-                onLaunchClaudeCode={handleLaunchAgent}
+                onSelectProvider={(provider) => {
+                  setSelectedAgent(provider);
+                  void onSetDefaultAgentProvider(provider);
+                }}
+                onLaunchAgent={handleLaunchAgent}
                 isLaunchingAgent={isLaunchingAgent}
                 isRunningStepId={runningSetupStepId}
               />
@@ -405,6 +405,7 @@ export const DeckPrimaryView = ({
       handleRunSetupStep,
       isLaunchingAgent,
       isWorkspaceSetupLoading,
+      onSetDefaultAgentProvider,
       runningSetupStepId,
       selectedAgent,
       shouldShowWorkspaceSetup,
@@ -446,7 +447,11 @@ export const DeckPrimaryView = ({
                 isLoading={isWorkspaceSetupLoading}
                 error={workspaceSetupError}
                 onRunStep={handleRunSetupStep}
-                onLaunchClaudeCode={handleLaunchAgent}
+                onSelectProvider={(provider) => {
+                  setSelectedAgent(provider);
+                  void onSetDefaultAgentProvider(provider);
+                }}
+                onLaunchAgent={handleLaunchAgent}
                 isLaunchingAgent={isLaunchingAgent}
                 isRunningStepId={runningSetupStepId}
               />

--- a/apps/web/src/components/PromptsPrimaryView.tsx
+++ b/apps/web/src/components/PromptsPrimaryView.tsx
@@ -88,7 +88,6 @@ export const PromptsPrimaryView = ({ enabled, onSidebarContent }: PromptsPrimary
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           workspaceMode: "shared",
-          agentProvider: "claude-code",
           promptTemplate: "meta-prompt-generator",
         }),
       });

--- a/apps/web/src/components/deck/WorkspaceSetupCard.tsx
+++ b/apps/web/src/components/deck/WorkspaceSetupCard.tsx
@@ -1,4 +1,8 @@
-import type { WorkspaceSetupSnapshot, WorkspaceSetupStepId } from "@octogent/core";
+import type {
+  TerminalAgentProvider,
+  WorkspaceSetupSnapshot,
+  WorkspaceSetupStepId,
+} from "@octogent/core";
 import { OctopusGlyph } from "../EmptyOctopus";
 
 type WorkspaceSetupCardProps = {
@@ -7,14 +11,15 @@ type WorkspaceSetupCardProps = {
   isLoading: boolean;
   error: string | null;
   onRunStep: (stepId: WorkspaceSetupStepId) => void;
-  onLaunchClaudeCode: () => void;
+  onSelectProvider: (provider: TerminalAgentProvider) => void;
+  onLaunchAgent: () => void;
   isLaunchingAgent?: boolean;
   isRunningStepId?: WorkspaceSetupStepId | null;
 };
 
 const buildStepSummary = (stepId: WorkspaceSetupStepId, description: string) => {
   if (stepId === "create-tentacles") {
-    return "Launch Claude Code so it can plan and create the first tentacles.";
+    return "Launch the selected coding agent so it can plan and create the first tentacles.";
   }
 
   return description;
@@ -26,7 +31,8 @@ export const WorkspaceSetupCard = ({
   isLoading,
   error,
   onRunStep,
-  onLaunchClaudeCode,
+  onSelectProvider,
+  onLaunchAgent,
   isLaunchingAgent,
   isRunningStepId,
 }: WorkspaceSetupCardProps) => (
@@ -55,10 +61,36 @@ export const WorkspaceSetupCard = ({
 
     {error ? <p className="workspace-setup-card-error">{error}</p> : null}
 
+    {(workspaceSetup?.providerChoices.length ?? 0) > 0 ? (
+      <div className="workspace-setup-provider">
+        <div className="workspace-setup-provider-copy">
+          <span className="workspace-setup-provider-title">Default Agent</span>
+          <span className="workspace-setup-provider-desc">
+            New planners and terminals use this provider unless a workflow overrides it.
+          </span>
+        </div>
+        <div className="workspace-setup-provider-options">
+          {workspaceSetup?.providerChoices.map((choice) => (
+            <button
+              key={choice.provider}
+              type="button"
+              className="workspace-setup-provider-option"
+              data-selected={choice.selected ? "true" : "false"}
+              disabled={!choice.available || isLoading}
+              onClick={() => onSelectProvider(choice.provider)}
+            >
+              {choice.label}
+              {!choice.available ? " unavailable" : ""}
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : null}
+
     <div className="workspace-setup-step-list">
       {(workspaceSetup?.steps ?? []).map((step) => {
         const isCreateTentaclesStep = step.id === "create-tentacles";
-        const buttonLabel = isCreateTentaclesStep ? "Launch Claude Code" : step.actionLabel;
+        const buttonLabel = isCreateTentaclesStep ? "Launch Agent" : step.actionLabel;
         const isButtonDisabled = isCreateTentaclesStep ? isLaunchingAgent : isLoading;
         const isButtonRunning = isCreateTentaclesStep
           ? isLaunchingAgent
@@ -84,7 +116,7 @@ export const WorkspaceSetupCard = ({
                 disabled={Boolean(isButtonDisabled)}
                 onClick={() => {
                   if (isCreateTentaclesStep) {
-                    onLaunchClaudeCode();
+                    onLaunchAgent();
                     return;
                   }
 

--- a/apps/web/src/styles/console-canvas-deck.css
+++ b/apps/web/src/styles/console-canvas-deck.css
@@ -1399,6 +1399,65 @@
   color: #ff9b8e;
 }
 
+.workspace-setup-provider {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(8, 10, 14, 0.62);
+}
+
+.workspace-setup-provider-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.workspace-setup-provider-title {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.workspace-setup-provider-desc {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.workspace-setup-provider-options {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.workspace-setup-provider-option {
+  min-height: 2.2rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font-family: var(--font-main);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.workspace-setup-provider-option[data-selected="true"] {
+  border-color: rgba(238, 194, 83, 0.48);
+  background: rgba(238, 194, 83, 0.14);
+}
+
+.workspace-setup-provider-option:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .workspace-setup-step-list {
   display: flex;
   flex-direction: column;
@@ -1517,8 +1576,13 @@
 @media (max-width: 720px) {
   .workspace-setup-step,
   .workspace-setup-card-header,
+  .workspace-setup-provider,
   .workspace-setup-card-actions-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .workspace-setup-provider-options {
+    justify-content: flex-start;
   }
 }

--- a/apps/web/tests/app-workspace-setup.test.tsx
+++ b/apps/web/tests/app-workspace-setup.test.tsx
@@ -11,6 +11,13 @@ const buildSetupSnapshot = (
 ): WorkspaceSetupSnapshot => ({
   isFirstRun: true,
   shouldShowSetupCard: true,
+  defaultAgentProvider: "claude-code",
+  configuredAgentProvider: null,
+  needsProviderSelection: true,
+  providerChoices: [
+    { provider: "claude-code", label: "Claude Code", available: true, selected: true },
+    { provider: "codex", label: "Codex", available: true, selected: false },
+  ],
   hasAnyTentacles: false,
   tentacleCount: 0,
   steps: [
@@ -89,6 +96,7 @@ const mockAppRequests = (
   resolveSetup: () => WorkspaceSetupSnapshot,
   options: {
     onEnsureGitignoreStep?: () => WorkspaceSetupSnapshot;
+    onProviderPatch?: (defaultAgentProvider: unknown) => WorkspaceSetupSnapshot;
   } = {},
 ) => {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -105,6 +113,16 @@ const mockAppRequests = (
 
     if (url.endsWith("/api/setup") && method === "GET") {
       return jsonResponse(resolveSetup());
+    }
+
+    if (url.endsWith("/api/setup") && method === "PATCH") {
+      const body =
+        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+      return jsonResponse(
+        options.onProviderPatch
+          ? options.onProviderPatch(body.defaultAgentProvider)
+          : resolveSetup(),
+      );
     }
 
     if (url.endsWith("/api/setup/steps/ensure-gitignore") && method === "POST") {
@@ -212,6 +230,48 @@ describe("App workspace setup", () => {
       const gitignoreStep = screen.getByText("Ignore .octogent").closest(".workspace-setup-step");
       expect(gitignoreStep).not.toBeNull();
       expect(within(gitignoreStep as HTMLElement).getByText("Done")).toBeInTheDocument();
+    });
+  });
+
+  it("persists the selected default provider from the setup card", async () => {
+    let currentSetup = buildSetupSnapshot();
+    const fetchMock = mockAppRequests(() => currentSetup, {
+      onProviderPatch: (defaultAgentProvider) => {
+        currentSetup = buildSetupSnapshot({
+          defaultAgentProvider: defaultAgentProvider === "codex" ? "codex" : "claude-code",
+          configuredAgentProvider: defaultAgentProvider === "codex" ? "codex" : "claude-code",
+          providerChoices: [
+            {
+              provider: "claude-code",
+              label: "Claude Code",
+              available: true,
+              selected: defaultAgentProvider !== "codex",
+            },
+            {
+              provider: "codex",
+              label: "Codex",
+              available: true,
+              selected: defaultAgentProvider === "codex",
+            },
+          ],
+        });
+        return currentSetup;
+      },
+    });
+
+    render(<App />);
+
+    const setupCard = await screen.findByLabelText("Workspace setup");
+    fireEvent.click(within(setupCard).getByRole("button", { name: "Codex" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/setup",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ defaultAgentProvider: "codex" }),
+        }),
+      );
     });
   });
 });

--- a/packages/core/src/domain/setup.ts
+++ b/packages/core/src/domain/setup.ts
@@ -1,10 +1,20 @@
+import type { TerminalAgentProvider } from "./agentRuntime";
+
 export type WorkspaceSetupStepId =
   | "initialize-workspace"
   | "ensure-gitignore"
+  | "check-codex"
   | "check-claude"
   | "check-git"
   | "check-curl"
   | "create-tentacles";
+
+export type WorkspaceSetupProviderChoice = {
+  provider: TerminalAgentProvider;
+  label: string;
+  available: boolean;
+  selected: boolean;
+};
 
 export type WorkspaceSetupStep = {
   id: WorkspaceSetupStepId;
@@ -21,6 +31,10 @@ export type WorkspaceSetupStep = {
 export type WorkspaceSetupSnapshot = {
   isFirstRun: boolean;
   shouldShowSetupCard: boolean;
+  defaultAgentProvider: TerminalAgentProvider;
+  configuredAgentProvider: TerminalAgentProvider | null;
+  needsProviderSelection: boolean;
+  providerChoices: WorkspaceSetupProviderChoice[];
   hasAnyTentacles: boolean;
   tentacleCount: number;
   steps: WorkspaceSetupStep[];


### PR DESCRIPTION
## Summary

Adds Phase 0 of Codex provider parity by making Octogent setup provider-aware.

- persists a default agent provider in setup state
- adds Codex as a first-run setup provider option
- adds API and CLI paths for setting or overriding the provider
- makes terminal, planner, and prompt creation use the selected default when no explicit provider is supplied
- adds focused API and web coverage for provider selection behavior

## Validation

- pnpm --filter @octogent/api test
- pnpm --filter @octogent/web test
- pnpm --filter @octogent/api build
- pnpm --filter @octogent/web build
- pnpm --filter @octogent/core build
- pnpm lint