### PR TITLE
fix: Windows dev server fails to start (spawn EINVAL + invalid workspace path)

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const DEFAULT_START_PORT = 8787;
 const MAX_PORT_ATTEMPTS = 200;
@@ -77,7 +78,7 @@ const apiOrigin = `http://127.0.0.1:${apiPort}`;
 
 console.log(`[octogent-dev] using api port ${apiPort}`);
 
-const monorepoRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const monorepoRoot = fileURLToPath(new URL("..", import.meta.url)).replace(/[\\/]$/, "");
 
 // Resolve project state dir from global registry.
 const resolveProjectStateDir = (workspaceCwd) => {
@@ -126,6 +127,7 @@ const child = spawn(
   ["-r", "--parallel", "--filter", "@octogent/api", "--filter", "@octogent/web", "dev"],
   {
     stdio: "inherit",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OCTOGENT_API_PORT: String(apiPort),


### PR DESCRIPTION
Fixes #26.

Two small, independent bugs in \`scripts/dev.mjs\` that together prevent \`pnpm dev\` from starting at all on Windows:

**1. \`spawn EINVAL\` launching the pnpm workspace filter**

Node's CVE-2024-27980 hardening (18.20.2+/20.12.2+/22.x) requires \`shell: true\` when spawning a \`.cmd\`/\`.bat\` file on Windows — without it, \`spawn()\` now throws \`EINVAL\` instead of silently working like it used to. The script already special-cases the Windows executable name (\`pnpm.cmd\`) but didn't set \`shell: true\` on the actual \`spawn()\` call.

**2. Invalid \`OCTOGENT_WORKSPACE_CWD\` default from \`import.meta.url\`**

\`new URL("..", import.meta.url).pathname\` on a \`file:///C:/Users/...\` URL returns \`/C:/Users/...\` — a leading slash before the drive letter that isn't a valid Windows path. This silently broke \`existsSync()\` checks against it, so the API server would log \`OCTOGENT_WORKSPACE_CWD directory does not exist\` and misbehave whenever no explicit \`OCTOGENT_WORKSPACE_CWD\` was set. Swapped to Node's \`fileURLToPath()\`, which handles the platform-specific conversion correctly.

## Testing

Verified locally on Windows 11 / Node 22.18.0:
- \`pnpm dev\` starts cleanly with no errors (previously failed immediately on bug 1)
- API server correctly resolves the workspace root with no explicit \`OCTOGENT_WORKSPACE_CWD\` set (previously failed on bug 2)
- Also verified with an explicit \`OCTOGENT_WORKSPACE_CWD\` pointed at a different project directory, to make sure the fix doesn't regress the non-default path

No changes to non-Windows behavior — both fixes are either Windows-only (\`shell: process.platform === "win32"\`) or strictly equivalent on POSIX (\`fileURLToPath\` vs manual \`.pathname\` parsing produce the same result on POSIX paths).